### PR TITLE
Mount health plan routes in app

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -15,6 +15,10 @@ app.get("/", (req, res) => {
   res.send("Jhoom backend is running");
 });
 
+// Health Plan routes
+const healthPlanRoutes = require("./routes/healthPlan.routes");
+app.use("/api/health-plan", healthPlanRoutes);
+
 // Main API routes
 app.use("/api/auth", authRoutes);
 app.use("/api/profile", profileRoutes);


### PR DESCRIPTION
 connects health plan routes to the main application.

## Changes
- Mounted health plan router at:
  /api/health-plan

## Impact
- Enables frontend access to health plan API endpoints
- Required for onboarding flow integration

## Notes
- No logic changes, only route registration