### PR TITLE
Add reusable API client for backend communication

### DIFF
--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -1,0 +1,20 @@
+const BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+
+export async function apiRequest(path, { method = "GET", token, body } = {}) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw new Error(data.error || "Request failed");
+  }
+
+  return data;
+}


### PR DESCRIPTION
This PR introduces a centralized API client to standardise all backend requests from the frontend. It removes repeated fetch logic and creates a single place to handle:

Base URL configuration
Auth token injection (JWT)
JSON request/response handling
Error formatting
What was added
client.js API helper
Centralised fetch wrapper for backend requests
Automatic JSON parsing
Standardised error handling
Support for Authorization: Bearer <token> header

Why this matters
Before this change, every API call would need duplicated fetch logic.
Now all future API modules (logs, health plan, social, etc.) reuse this client.

Impact
Cleaner code
Easier debugging
Consistent auth handling
Required foundation for all future API modules
