### PR TITLE
Connect Food Log screen to backend logs API

### DIFF
--- a/frontend/app/(tabs)/food-log.js
+++ b/frontend/app/(tabs)/food-log.js
@@ -1,13 +1,46 @@
 import { SafeAreaView, StyleSheet, Text, View } from "react-native";
 
+//import React hooks + logs API
+import { useEffect, useState } from "react";
+import { getLogs } from "../services/api/logsApi";
+
 export default function FoodLogScreen() {
+  //state to store logs from backend
+  const [logs, setLogs] = useState([]);
+ // TEMP: hardcoded token for testing (replace later with auth store)
+  const token = "PASTE_YOUR_TOKEN_HERE";
+
+  //runs when screen loads
+  useEffect(() => {
+    loadLogs();
+  }, []);
+
+  //function to fetch logs from backend
+  async function loadLogs() {
+    try {
+      const data = await getLogs(token);
+      setLogs(data);
+    } catch (err) {
+      console.log("Error loading logs:", err);
+    }
+  }
+  
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
         <Text style={styles.title}>Food Log</Text>
         <Text style={styles.text}>
           This is where users will log meals, calories, and nutrition.
-        </Text>
+        </Text> 
+  //display logs from backend 
+  {logs.map((log) => (
+          <View key={log.id} style={{ marginTop: 10 }}>
+            <Text>{log.name}</Text>
+            <Text>{log.typeKey}</Text>
+            <Text>{log.dateKey}</Text>
+          </View>
+        ))}
+          
       </View>
     </SafeAreaView>
   );


### PR DESCRIPTION
This PR connects the Food Log screen to the backend logs API, replacing static placeholder content with real data from the database.

##What was added
Integrated getLogs API into food-log.js
Added state (useState) to store logs from backend
Added useEffect to fetch logs when the screen loads
Rendered logs dynamically in the UI
Added fallback message when no logs are available

##Backend integration
This screen now fetches data from:

GET /api/logs
 Auth (temporary)
A hardcoded token is currently used for testing
This will be replaced with proper auth state management later

##Why this matters
Enables real user data instead of mock/static content
Establishes frontend ↔ backend connection pattern
Prepares other log screens (e.g. workout log) for integration
