### PR TITLE
Connect Workout Log screen to backend logs API

### DIFF
--- a/frontend/app/(tabs)/workout-log.js
+++ b/frontend/app/(tabs)/workout-log.js
@@ -1,6 +1,30 @@
 import { SafeAreaView, StyleSheet, Text, View } from "react-native";
 
+//import hooks + logs API
+import { useEffect, useState } from "react";
+import { getLogs } from "../services/api/logsApi";
+
 export default function WorkoutLogScreen() {
+  //state to store logs
+  const [logs, setLogs] = useState([]);
+  //TEMP: hardcoded token for testing
+  const token = "PASTE_YOUR_TOKEN_HERE";
+
+  //load logs when screen opens
+  useEffect(() => {
+    loadLogs();
+  }, []);
+
+  //fetch logs from backend
+  async function loadLogs() {
+    try {
+      const data = await getLogs(token);
+      setLogs(data);
+    } catch (err) {
+      console.log("Error loading logs:", err);
+    }
+  }
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
@@ -8,6 +32,19 @@ export default function WorkoutLogScreen() {
         <Text style={styles.text}>
           This is where users will log exercises, sets, reps, and weights.
         </Text>
+    {/* show message if no logs */}
+        {logs.length === 0 && (
+          <Text style={{ marginTop: 10 }}>No logs yet</Text>
+        )}
+
+        {/* render logs */}
+        {logs.length > 0 && logs.map((log) => (
+          <View key={log.id} style={{ marginTop: 10 }}>
+            <Text>{log.name}</Text>
+            <Text>{log.typeKey}</Text>
+            <Text>{log.dateKey}</Text>
+          </View>
+        ))}
       </View>
     </SafeAreaView>
   );


### PR DESCRIPTION
This PR connects the Workout Log screen to the backend logs API, replacing static placeholder content with dynamic data fetched from the database.

##What was added
Integrated getLogs API into workout-log.js
Added useState to store logs from backend
Added useEffect to fetch logs on screen load
Rendered logs dynamically in the UI
Added fallback message when no logs are available
Backend integration

##This screen now fetches data from:
GET /api/logs
Auth (temporary)
Uses a hardcoded token for testing
Will be replaced with proper auth state management later

##Why this matters
Enables real workout data instead of static UI
Keeps consistency with Food Log integration
Establishes reusable frontend → backend pattern
