### PR TITLE
Add Health Plan API service for backend integration

### DIFF
--- a/frontend/api/healthPlanApi.js
+++ b/frontend/api/healthPlanApi.js
@@ -1,0 +1,33 @@
+import { apiRequest } from "./client";
+
+/**
+ * Generate a health plan from onboarding answers
+ */
+export const generateHealthPlan = (token, data) => {
+  return apiRequest("/health-plan/generate", {
+    method: "POST",
+    token,
+    body: data,
+  });
+};
+
+/**
+ * Get existing health plan for user
+ */
+export const getHealthPlan = (token) => {
+  return apiRequest("/health-plan", {
+    method: "GET",
+    token,
+  });
+};
+
+/**
+ * Update health plan (optional)
+ */
+export const updateHealthPlan = (token, data) => {
+  return apiRequest("/health-plan", {
+    method: "PUT",
+    token,
+    body: data,
+  });
+};


### PR DESCRIPTION
This PR adds a dedicated Health Plan API service layer to the frontend. It enables the onboarding flow to communicate with the backend health plan endpoints instead of using local state.

## API Functions Added
generateHealthPlan(token, data)
Sends onboarding answers to backend
Creates or updates a user health plan
getHealthPlan(token)
Fetches existing saved health plan for the user
updateHealthPlan(token, data)
Updates an existing health plan (optional support for future edits)

##Why this change is needed
Prepares onboarding flow for backend integration
Replaces temporary/local health plan logic
Ensures consistent API structure (same pattern as logs API)
Keeps API logic separated from UI screens
Backend Integration

##This connects to:

POST /api/health-plan/generate
GET /api/health-plan
PUT /api/health-plan
